### PR TITLE
Make TopologyHints more intuitive 

### DIFF
--- a/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
@@ -51,9 +51,9 @@ func (m *fakeManager) RemoveContainer(containerID string) error {
 	return nil
 }
 
-func (m *fakeManager) GetTopologyHints(pod v1.Pod, container v1.Container) topologymanager.TopologyHints {
+func (m *fakeManager) GetTopologyHints(pod v1.Pod, container v1.Container) ([]topologymanager.TopologyHint, bool) {
        klog.Infof("[fake cpumanager] Get Topology Hints")
-       return topologymanager.TopologyHints{}
+       return []topologymanager.TopologyHint{}, false
 }
 
 func (m *fakeManager) State() state.Reader {

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -189,8 +189,8 @@ func (p *staticPolicy) AddContainer(s state.State, pod *v1.Pod, container *v1.Co
         	klog.Infof("[cpumanager] Pod %v, Container %v Topology Affinity is: %v", pod.UID, container.Name, containerTopologyHints)
 
                 sockets := make(map[int]bool)
-               	for _, bitMasks := range containerTopologyHints.SocketAffinity {
-                    for counter, bit := range bitMasks {
+               	for _, hint := range containerTopologyHints {
+                    for counter, bit := range hint.SocketMask {
                         if bit == int64(1) {
                             sockets[counter] = true
                         }

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -185,16 +185,14 @@ func (p *staticPolicy) AddContainer(s state.State, pod *v1.Pod, container *v1.Co
 		}
 
 		//Call Topology Manager to get Container affinity
-        	containerTopologyHints := p.affinity.GetAffinity(string(pod.UID), container.Name)
-        	klog.Infof("[cpumanager] Pod %v, Container %v Topology Affinity is: %v", pod.UID, container.Name, containerTopologyHints)
+        	containerTopologyHint := p.affinity.GetAffinity(string(pod.UID), container.Name)
+        	klog.Infof("[cpumanager] Pod %v, Container %v Topology Affinity is: %v", pod.UID, container.Name, containerTopologyHint)
 
                 sockets := make(map[int]bool)
-               	for _, hint := range containerTopologyHints {
-                    for counter, bit := range hint.SocketMask {
-                        if bit == int64(1) {
-                            sockets[counter] = true
+                for counter, bit := range containerTopologyHint.SocketMask {
+                	if bit == int64(1) {
+                        	sockets[counter] = true
                         }
-                    }
                 }
 		cpuset, err := p.allocateCPUs(s, numCPUs, sockets)
 		if err != nil {

--- a/pkg/kubelet/cm/cpumanager/topology_hints.go
+++ b/pkg/kubelet/cm/cpumanager/topology_hints.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpumanager
+
+import (
+	"math"
+	"k8s.io/api/core/v1"
+	"k8s.io/klog"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/socketmask"
+)
+
+
+func (m *manager) GetTopologyHints(pod v1.Pod, container v1.Container) ([]topologymanager.TopologyHint, bool) {
+    	var cpuHints []topologymanager.TopologyHint	
+    	for resourceObj, amountObj := range container.Resources.Requests {
+        	resource := string(resourceObj)
+        	amount := int(amountObj.Value())
+        	requested := int64(amount)
+        	if resource != "cpu" {
+                	continue
+            	}
+        
+        	klog.Infof("[cpumanager] Guaranteed CPUs detected: %v", amount)
+
+            	topo, err := topology.Discover(m.machineInfo)
+            	if err != nil {
+                    klog.Infof("[cpu manager] error discovering topology")
+            	}
+	
+		assignableCPUs := m.getAssignableCPUs(topo)
+        	cpuAccum := newCPUAccumulator(topo, assignableCPUs, amount)     
+
+            	socketCount := topo.NumSockets
+            	klog.Infof("[cpumanager] Number of sockets on machine (available and unavailable): %v", socketCount)
+		cpuHints = getCPUMask(socketCount, cpuAccum, requested)
+    	}  
+    	return cpuHints, true 
+}
+
+func (m *manager) getAssignableCPUs(topo *topology.CPUTopology) cpuset.CPUSet {
+	allCPUs := topo.CPUDetails.CPUs()
+	klog.Infof("[cpumanager] Shared CPUs: %v", allCPUs)        
+      	reservedCPUs := m.nodeAllocatableReservation[v1.ResourceCPU]
+	reservedCPUsFloat := float64(reservedCPUs.MilliValue()) / 1000
+      	numReservedCPUs := int(math.Ceil(reservedCPUsFloat))        
+      	reserved, _ := takeByTopology(topo, allCPUs, numReservedCPUs)
+        klog.Infof("[cpumanager] Reserved CPUs: %v", reserved)
+      	assignableCPUs := m.state.GetDefaultCPUSet().Difference(reserved)
+      	klog.Infof("[cpumanager] Assignable CPUs (Shared - Reserved): %v", assignableCPUs)
+	return assignableCPUs
+}
+
+func getCPUMask(socketCount int, cpuAccum *cpuAccumulator, requested int64) []topologymanager.TopologyHint {
+	CPUsInSocketSize := make([]int64, socketCount)
+	var mask []int64
+	var totalCPUs int64 = 0
+      	var cpuHintsTemp [][]int64 
+      	for i := 0; i < socketCount; i++ {
+        	CPUsInSocket := cpuAccum.details.CPUsInSocket(i)
+              	klog.Infof("[cpumanager] Assignable CPUs on Socket %v: %v", i, CPUsInSocket)
+		CPUsInSocketSize[i] = int64(CPUsInSocket.Size()) 
+              	totalCPUs += CPUsInSocketSize[i]
+            	if CPUsInSocketSize[i] >= requested {
+                  	for j := 0; j < socketCount; j++ { 
+                         	if j == i { 
+                                	mask = append(mask, 1)
+                           	} else {        
+                                	mask = append(mask, 0)
+                             	}
+                   	}
+                 	cpuHintsTemp = append(cpuHintsTemp, mask)
+                   	mask = nil
+           	}                        
+  	}
+	if totalCPUs >= requested {
+		crossSocketMask := buildCrossSocketMask(socketCount, CPUsInSocketSize)  		
+           	cpuHintsTemp = append(cpuHintsTemp, crossSocketMask)
+  	}
+	klog.Infof("[cpumanager] Number of Assignable CPUs per Socket: %v", CPUsInSocketSize)   
+      	klog.Infof("[cpumanager] Topology Affinities for pod: %v", cpuHintsTemp)             
+      	cpuHints := make([]topologymanager.TopologyHint, len(cpuHintsTemp))
+	for r := range cpuHintsTemp {
+          	cpuSocket := socketmask.SocketMask(cpuHintsTemp[r])
+       		cpuHints[r].SocketMask = cpuSocket
+   	}
+	return cpuHints
+}
+
+func buildCrossSocketMask(socketCount int, CPUsInSocketSize []int64) []int64 {
+	var mask []int64
+	for i := 0; i < socketCount; i++ {
+		if CPUsInSocketSize[i] == 0 {
+             		mask = append(mask, 0)
+           	} else {
+           		mask = append(mask, 1)
+         	}	
+	}
+	return mask
+}

--- a/pkg/kubelet/cm/cpumanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology_hints_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpumanager
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/socketmask"
+)
+
+func TestGetTopologyHints(t *testing.T) {
+	tcases := []struct {
+		name     	string
+		amount   	int64
+		expectedHints	[]topologymanager.TopologyHint
+		expectedAdmit	bool
+	}{
+		{
+			name:   "Socket Affinity includes {0, 1}, {1, 0}, {1, 1}",
+			amount: 1,
+			expectedHints:	[]topologymanager.TopologyHint{
+						topologymanager.TopologyHint{
+							SocketMask: socketmask.SocketMask{1, 0},
+						},
+						topologymanager.TopologyHint{
+                                                        SocketMask: socketmask.SocketMask{0, 1},
+                                                }, 
+						topologymanager.TopologyHint{
+                                                        SocketMask: socketmask.SocketMask{1, 1},
+                                                }, 	
+					},
+			expectedAdmit:	true,	
+		},
+		{
+			name:   "Socket Affinity includes {1, 1}",
+			amount: 2,
+			expectedHints: 	[]topologymanager.TopologyHint{
+						topologymanager.TopologyHint{
+							SocketMask: socketmask.SocketMask{1, 1},
+						},
+					},
+			expectedAdmit:  false,
+		},
+	}
+
+	for _, tc := range tcases {
+		m := manager{}
+
+		testPod := v1.Pod{}
+		testContainer := v1.Container{}
+
+		name := v1.ResourceName("testdevice")
+
+		testResourceList := make(map[v1.ResourceName]resource.Quantity)
+		testResourceList[name] = *resource.NewQuantity(tc.amount, "")
+
+		testContainer.Resources.Requests = testResourceList
+		hint,admit := m.GetTopologyHints(testPod, testContainer)
+		if reflect.DeepEqual(hint, tc.expectedHints) || reflect.DeepEqual(admit, tc.expectedAdmit) {
+			t.Errorf("Expected in result to be %v and %v, got %v ad %v", tc.expectedHints, tc.expectedAdmit, hint, admit)
+		}
+	}
+}

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -146,7 +146,7 @@ func newManagerImpl(socketPath string, topologyAffinityStore topologymanager.Sto
 
 	return manager, nil
 }
-    	
+
 func (m *ManagerImpl) genericDeviceUpdateCallback(resourceName string, devices []pluginapi.Device) {
 	m.mutex.Lock()
 	m.healthyDevices[resourceName] = sets.NewString()
@@ -627,12 +627,12 @@ func (m *ManagerImpl) devicesToAllocate(podUID, contName, resource string, requi
 	}
     
     	//Get Topology Mask for pod/container here, check available against devices to get devices that have the same socket and update available to these
-    	podTopologyAffinity := m.topologyAffinityStore.GetAffinity(podUID, contName)
-    	klog.Infof("Topology Affinities for pod %v container %v are: %v", podUID, contName, podTopologyAffinity)
+    	podTopology := m.topologyAffinityStore.GetAffinity(podUID, contName)
+    	klog.Infof("Topology Affinities for pod %v container %v are: %v", podUID, contName, podTopology)
     
     	sockets := make(map[int]bool)
-    	for _, bitMasks := range podTopologyAffinity.SocketAffinity {
-       		for counter, bit := range bitMasks {
+    	for _, hint  := range podTopology {
+       		for counter, bit := range hint.SocketMask {
                 	if bit == int64(1) {
                         	sockets[counter] = true
                 	}

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -631,12 +631,10 @@ func (m *ManagerImpl) devicesToAllocate(podUID, contName, resource string, requi
     	klog.Infof("Topology Affinities for pod %v container %v are: %v", podUID, contName, podTopology)
     
     	sockets := make(map[int]bool)
-    	for _, hint  := range podTopology {
-       		for counter, bit := range hint.SocketMask {
-                	if bit == int64(1) {
-                        	sockets[counter] = true
-                	}
-            	}
+       	for counter, bit := range podTopology.SocketMask {
+               	if bit == int64(1) {
+                       	sockets[counter] = true
+               	}
         }
 
         allocated := available.UnsortedList()[:needed]

--- a/pkg/kubelet/cm/devicemanager/manager_stub.go
+++ b/pkg/kubelet/cm/devicemanager/manager_stub.go
@@ -70,8 +70,8 @@ func (h *ManagerStub) GetWatcherHandler() pluginwatcher.PluginHandler {
 	return nil
 }
 
-func (h *ManagerStub) GetTopologyHints(pod v1.Pod, container v1.Container) topologymanager.TopologyHints {
-       return topologymanager.TopologyHints{}
+func (h *ManagerStub) GetTopologyHints(pod v1.Pod, container v1.Container) ([]topologymanager.TopologyHint, bool) {
+       return []topologymanager.TopologyHint{}, false
 }
 
 // GetDevices returns nil

--- a/pkg/kubelet/cm/devicemanager/topology_test.go
+++ b/pkg/kubelet/cm/devicemanager/topology_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package devicemanager
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/socketmask"
+)
+
+func TestGetTopologyHints(t *testing.T) {
+	tcases := []struct {
+		name     	string
+		amount   	int64
+		expectedHints 	[]topologymanager.TopologyHint
+		expectedAdmit	bool
+	}{
+		{
+			name:   	"Socket Masks include {0, 1}, {1, 0}, {1, 1}",
+			amount: 	1,
+			expectedHints: []topologymanager.TopologyHint{
+						topologymanager.TopologyHint{
+							SocketMask: socketmask.SocketMask{0, 1},
+						},
+						topologymanager.TopologyHint{
+                                                	SocketMask: socketmask.SocketMask{1, 0},
+                                        	},
+						topologymanager.TopologyHint{
+                                                	SocketMask: socketmask.SocketMask{1, 1},
+                                        	},
+					},
+			expectedAdmit:	true,
+		},
+		{
+			name:   	"Socket Mask includes {1, 1}",
+			amount: 	2,
+			expectedHints: 	[]topologymanager.TopologyHint{
+						topologymanager.TopologyHint{
+							SocketMask: socketmask.SocketMask{1, 1},
+						},
+					},
+			expectedAdmit:       false,
+		},
+	}
+
+	for _, tc := range tcases {
+		m := ManagerImpl{}
+
+		testPod := v1.Pod{}
+		testContainer := v1.Container{}
+
+		testDevices := make(map[string][]pluginapi.Device)
+		testDevice1 := pluginapi.Device{ID: "ID", Health: pluginapi.Healthy, Topology: &pluginapi.TopologyInfo{Socket: int64(0)}}
+		testDevice2 := pluginapi.Device{ID: "ID", Health: pluginapi.Healthy, Topology: &pluginapi.TopologyInfo{Socket: int64(1)}}
+		testDevices["testdevice"] = []pluginapi.Device{testDevice1, testDevice2}
+
+		name := v1.ResourceName("testdevice")
+
+		testResourceList := make(map[v1.ResourceName]resource.Quantity)
+		testResourceList[name] = *resource.NewQuantity(tc.amount, "")
+
+		testContainer.Resources.Requests = testResourceList
+		hints, admit := m.GetTopologyHints(testPod, testContainer)
+		if reflect.DeepEqual(hints, tc.expectedHints) || reflect.DeepEqual(admit, tc.expectedAdmit) {
+			t.Errorf("Expected in result to be %v and %v, got %v and %v", tc.expectedHints, tc.expectedAdmit, hints, admit)
+		}
+	}
+}

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -63,7 +63,7 @@ type Manager interface {
 	
 	// TopologyManager HintProvider provider indicates the Device Manager implements the Topology Manager Interface
      	// and is consulted to make Topology aware resource alignments
-     	GetTopologyHints(pod v1.Pod, container v1.Container) topologymanager.TopologyHints
+     	GetTopologyHints(pod v1.Pod, container v1.Container) ([]topologymanager.TopologyHint, bool)
 }
 
 // DeviceRunContainerOptions contains the combined container runtime settings to consume its allocated devices.

--- a/pkg/kubelet/cm/internal_container_lifecycle.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle.go
@@ -46,7 +46,7 @@ func (i *internalContainerLifecycleImpl) PreStartContainer(pod *v1.Pod, containe
 		}
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.TopologyManager) {
-		err := i.topologyManager.AddPod(pod, containerID)
+		err := i.topologyManager.AddContainer(pod, containerID)
                 if err != nil {
                         return err
                 }
@@ -69,7 +69,7 @@ func (i *internalContainerLifecycleImpl) PostStopContainer(containerID string) e
 		} 
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.TopologyManager) {
-                err := i.topologyManager.RemovePod(containerID)
+                err := i.topologyManager.RemoveContainer(containerID)
                 if err != nil {
                         return err
                 }        

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -24,9 +24,9 @@ func NewFakeManager() Manager {
  	return &fakeManager{}
 }
 
-func (m *fakeManager) GetAffinity(podUID string, containerName string) TopologyHints {
+func (m *fakeManager) GetAffinity(podUID string, containerName string) []TopologyHint {
 	klog.Infof("[fake topologymanager] GetAffinity podUID: %v container name:  %v", podUID, containerName)
- 	return TopologyHints{}
+	return []TopologyHint{}
 }
 
 func (m *fakeManager) AddHintProvider(h HintProvider) {

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -24,9 +24,9 @@ func NewFakeManager() Manager {
  	return &fakeManager{}
 }
 
-func (m *fakeManager) GetAffinity(podUID string, containerName string) []TopologyHint {
+func (m *fakeManager) GetAffinity(podUID string, containerName string) TopologyHint {
 	klog.Infof("[fake topologymanager] GetAffinity podUID: %v container name:  %v", podUID, containerName)
-	return []TopologyHint{}
+	return TopologyHint{}
 }
 
 func (m *fakeManager) AddHintProvider(h HintProvider) {

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -33,13 +33,13 @@ func (m *fakeManager) AddHintProvider(h HintProvider) {
 	klog.Infof("[fake topologymanager] AddHintProvider HintProvider:  %v", h)
 }
 
-func (m *fakeManager) AddPod(pod *v1.Pod, containerID string) error {
-	klog.Infof("[fake topologymanager] AddPod  pod: %v container id:  %v", pod, containerID)
+func (m *fakeManager) AddContainer(pod *v1.Pod, containerID string) error {
+	klog.Infof("[fake topologymanager] AddContainer  pod: %v container id:  %v", pod, containerID)
 	return nil
 }
 
-func (m *fakeManager) RemovePod (containerID string) error {
-	klog.Infof("[fake topologymanager] RemovePod container id:  %v", containerID)
+func (m *fakeManager) RemoveContainer (containerID string) error {
+	klog.Infof("[fake topologymanager] RemoveContainer container id:  %v", containerID)
 	return nil 
 }
 

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologymanager
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+)
+
+func TestNewFakeManager(t *testing.T) {
+	fm := NewFakeManager()
+
+	if _, ok := fm.(Manager); !ok {
+		t.Errorf("Result is not Manager type")
+
+	}
+}
+
+func TestFakeGetAffinity(t *testing.T) {
+	tcases := []struct {
+		name          string
+		containerName string
+		podUID        string
+		expected      TopologyHint
+	}{
+		{
+			name:          "Case1",
+			containerName: "nginx",
+			podUID:        "0aafa4c4-38e8-11e9-bcb1-a4bf01040474",
+		},
+	}
+	for _, tc := range tcases {
+		fm := fakeManager{}
+		actual := fm.GetAffinity(tc.podUID, tc.containerName)
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("Expected Affinity in result to be %v, got %v", tc.expected, actual)
+		}
+	}
+}
+
+func TestFakeAddContainer(t *testing.T) {
+	testCases := []struct {
+		name        string
+		containerID string
+		podUID      types.UID
+	}{
+		{
+			name:        "Case1",
+			containerID: "nginx",
+			podUID:      "0aafa4c4-38e8-11e9-bcb1-a4bf01040474",
+		},
+		{
+			name:        "Case2",
+			containerID: "Busy_Box",
+			podUID:      "b3ee37fc-39a5-11e9-bcb1-a4bf01040474",
+		},
+	}
+	fm := fakeManager{}
+	mngr := manager{}
+	mngr.podMap = make(map[string]string)
+	for _, tc := range testCases {
+		pod := v1.Pod{}
+		pod.UID = tc.podUID
+		err := fm.AddContainer(&pod, tc.containerID)
+		if err != nil {
+			t.Errorf("Expected error to be nil but got: %v", err)
+
+		}
+
+	}
+}
+
+func TestFakeRemoveContainer(t *testing.T) {
+	testCases := []struct {
+		name        string
+		containerID string
+		podUID      string
+	}{
+		{
+			name:        "Case1",
+			containerID: "nginx",
+			podUID:      "0aafa4c4-38e8-11e9-bcb1-a4bf01040474",
+		},
+		{
+			name:        "Case2",
+			containerID: "Busy_Box",
+			podUID:      "b3ee37fc-39a5-11e9-bcb1-a4bf01040474",
+		},
+	}
+	fm := fakeManager{}
+	mngr := manager{}
+	mngr.podMap = make(map[string]string)
+	for _, tc := range testCases {
+		err := fm.RemoveContainer(tc.containerID)
+		if err != nil {
+			t.Errorf("Expected error to be nil but got: %v", err)
+		}
+
+	}
+
+}
+
+func TestFakeAdmit(t *testing.T) {
+	tcases := []struct {
+		name     string
+		result   lifecycle.PodAdmitResult
+		qosClass v1.PodQOSClass
+		expected bool
+	}{
+		{
+			name:     "QOSClass set as Gauranteed",
+			result:   lifecycle.PodAdmitResult{},
+			qosClass: "Guaranteed",
+			expected: true,
+		},
+		{
+			name:     "QOSClass set as Burstable",
+			result:   lifecycle.PodAdmitResult{},
+			qosClass: "Burstable",
+			expected: true,
+		},
+		{
+			name:     "QOSClass set as BestEffort",
+			result:   lifecycle.PodAdmitResult{},
+			qosClass: "BestEffort",
+			expected: true,
+		},
+	}
+	fm := fakeManager{}
+	for _, tc := range tcases {
+		mngr := manager{}
+		mngr.podTopologyHints = make(map[string]containers)
+		podAttr := lifecycle.PodAdmitAttributes{}
+		pod := v1.Pod{}
+		pod.Status.QOSClass = tc.qosClass
+		podAttr.Pod = &pod
+		actual := fm.Admit(&podAttr)
+		if reflect.DeepEqual(actual, tc.result) {
+			t.Errorf("Error occured, expected Admit in result to be %v got %v", tc.result, actual.Admit)
+		}
+	}
+}

--- a/pkg/kubelet/cm/topologymanager/policy.go
+++ b/pkg/kubelet/cm/topologymanager/policy.go
@@ -18,5 +18,5 @@ import (
 
 type Policy interface {
     Name() string
-    CanAdmitPodResult (result TopologyHints) lifecycle.PodAdmitResult 
+    CanAdmitPodResult (admit bool) lifecycle.PodAdmitResult 
 }

--- a/pkg/kubelet/cm/topologymanager/policy_preferred.go
+++ b/pkg/kubelet/cm/topologymanager/policy_preferred.go
@@ -30,7 +30,7 @@ func (p *preferredPolicy) Name() string {
     return string(PolicyPreferred)
 }
 
-func (p *preferredPolicy) CanAdmitPodResult (result TopologyHints) lifecycle.PodAdmitResult {
+func (p *preferredPolicy) CanAdmitPodResult (admit bool) lifecycle.PodAdmitResult {
         return lifecycle.PodAdmitResult{
             Admit:   true,          
         }

--- a/pkg/kubelet/cm/topologymanager/policy_preferred_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_preferred_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologymanager
+
+import (
+	"testing"
+)
+
+func TestCanAdmitPodResult1(t *testing.T) {
+	tcases := []struct {
+		name     string
+		admit    bool
+		expected bool
+	}{
+		{
+			name:     "Affinity is set to false in topology hints",
+			admit:    false,
+			expected: true,
+		},
+		{
+			name:     "Affinity is set to true in topology hints",
+			admit:    true,
+			expected: true,
+		},
+	}
+
+	for _, tc := range tcases {
+		policy := NewPreferredPolicy()
+		admit := tc.admit
+		result := policy.CanAdmitPodResult(admit)
+
+		if result.Admit != tc.expected {
+			t.Errorf("Expected Admit field in result to be %t, got %t", tc.expected, result.Admit)
+		}
+	}
+}

--- a/pkg/kubelet/cm/topologymanager/policy_strict.go
+++ b/pkg/kubelet/cm/topologymanager/policy_strict.go
@@ -30,9 +30,8 @@ func (p *strictPolicy) Name() string {
 	return string(PolicyStrict)
 }
 
-func (p *strictPolicy) CanAdmitPodResult (result TopologyHints) lifecycle.PodAdmitResult {
-    	affinity := result.Affinity
-    	if !affinity {
+func (p *strictPolicy) CanAdmitPodResult (admit bool) lifecycle.PodAdmitResult {
+    	if !admit {
     		return lifecycle.PodAdmitResult{
         		Admit:  false,
         		Reason:	 "Topology Affinity Error",

--- a/pkg/kubelet/cm/topologymanager/policy_strict_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_strict_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologymanager
+
+import (
+	"testing"
+)
+
+func TestCanAdmitPodResult(t *testing.T) {
+	tcases := []struct {
+		name     string
+		admit    bool
+		expected bool
+	}{
+		{
+			name:     "Affinity is set to false in topology hints",
+			admit:    false,
+			expected: false,
+		},
+		{
+			name:     "Affinity is set to true in topology hints",
+			admit:    true,
+			expected: true,
+		},
+	}
+
+	for _, tc := range tcases {
+		policy := NewStrictPolicy()
+		admit := tc.admit
+		result := policy.CanAdmitPodResult(admit)
+
+		if result.Admit != tc.expected {
+			t.Errorf("Expected Admit field in result to be %t, got %t", tc.expected, result.Admit)
+		}
+
+		if tc.expected == false {
+			if len(result.Reason) == 0 {
+				t.Errorf("Expected Reason field to be not empty")
+			}
+			if len(result.Message) == 0 {
+				t.Errorf("Expected Message field to be not empty")
+			}
+		}
+	}
+}

--- a/pkg/kubelet/cm/topologymanager/socketmask/socketmask.go
+++ b/pkg/kubelet/cm/topologymanager/socketmask/socketmask.go
@@ -33,18 +33,12 @@ func NewSocketMask(Mask []int64) SocketMask {
 }
 
 // GetSocketMask calculates the socket mask. 
-func (sm SocketMask) GetSocketMask(socketMask []SocketMask, maskHolder []string, count int) (SocketMask, []string) {
-	var socketAffinityInt64 [][]int64
-      	for r := range socketMask {
-       		socketAffinityVals := []int64(socketMask[r])
-          	socketAffinityInt64 = append(socketAffinityInt64,socketAffinityVals)
-    	}
+func (sm SocketMask) GetSocketMask(socketMaskInt64 [][]int64, maskHolder []string, count int) (SocketMask, []string) {
        	if count == 0 {
-            	maskHolder = buildMaskHolder(socketAffinityInt64)
+            	maskHolder = buildMaskHolder(socketMaskInt64)
 	}
       	klog.V(4).Infof("[socketmask] MaskHolder : %v", maskHolder) 
-        klog.V(4).Infof("[socketmask] %v is passed into arrange function", socketMask)   
-        arrangedMask := arrangeMask(socketAffinityInt64)                   
+        arrangedMask := arrangeMask(socketMaskInt64)                   
         newMask := getTopologyAffinity(arrangedMask, maskHolder)
        	klog.V(4).Infof("[socketmask] New Mask after getTopologyAffinity (new mask) : %v ",newMask)
         finalMaskValue := parseMask(newMask)

--- a/pkg/kubelet/cm/topologymanager/socketmask/socketmask_test.go
+++ b/pkg/kubelet/cm/topologymanager/socketmask/socketmask_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package socketmask
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetSocketmask(t *testing.T) {
+	tcases := []struct {
+		name                    string
+		socketmask		[][]int64
+		maskholder              []string
+		count                   int
+		expectedMaskHolder      []string
+		expectedFinalSocketMask SocketMask
+	}{
+		{
+			name:                    "Empty MaskHolder and count set as 0",
+			socketmask:              [][]int64{{1, 0}, {0, 1}, {1, 1}},
+			maskholder:              []string{""},
+			count:                   0,
+			expectedMaskHolder:      []string{"10", "01", "11"},
+			expectedFinalSocketMask: SocketMask{1, 0},
+		},
+		{
+			name:                    "MaskHolder non zero, count set as 1",
+			socketmask:              [][]int64{{1, 0}, {0, 1}, {1, 1}},
+			maskholder:              []string{"10", "01", "11"},
+			count:                   1,
+			expectedMaskHolder:      []string{"10", "01", "11"},
+			expectedFinalSocketMask: SocketMask{1, 0},
+		},
+
+		{
+			name:                    "Empty MaskHolder and count set as 0",
+			socketmask:              [][]int64{{0, 1}, {1, 1}},
+			maskholder:              []string{""},
+			count:                   0,
+			expectedMaskHolder:      []string{"01", "11"},
+			expectedFinalSocketMask: SocketMask{0, 1},
+		},
+		{
+			name:                    "MaskHolder non zero, count set as 1",
+			socketmask:              [][]int64{{0, 1}, {1, 1}},
+			maskholder:              []string{"01", "11"},
+			count:                   1,
+			expectedMaskHolder:      []string{"01", "11"},
+			expectedFinalSocketMask: SocketMask{0, 1},
+		},
+	}
+
+	for _, tc := range tcases {
+
+		sm := NewSocketMask(nil)
+		actualSocketMask, actualMaskHolder := sm.GetSocketMask(tc.socketmask, tc.maskholder, tc.count)
+		if !reflect.DeepEqual(actualSocketMask, tc.expectedFinalSocketMask) {
+			t.Errorf("Expected final socketmask to be %v, got %v", tc.expectedFinalSocketMask, actualSocketMask)
+		}
+
+		if !reflect.DeepEqual(actualMaskHolder, tc.expectedMaskHolder) {
+			t.Errorf("Expected maskholder to be %v, got %v", tc.expectedMaskHolder, actualMaskHolder)
+		}
+
+	}
+}
+
+func TestNewSocketMask(t *testing.T) {
+	tcases := []struct {
+		name         string
+		Mask         []int64
+		expectedMask []int64
+	}{
+		{
+			name:         "Mask as an int64 binary array",
+			Mask:         []int64{1, 0},
+			expectedMask: []int64{1, 0},
+		},
+	}
+
+	for _, tc := range tcases {
+
+		sm := NewSocketMask(nil)
+
+		if reflect.DeepEqual(sm, tc.expectedMask) {
+			t.Errorf("Expected socket mask to be %v, got %v", tc.expectedMask, sm)
+		}
+	}
+}

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -21,8 +21,8 @@ import (
 type Manager interface {
  	lifecycle.PodAdmitHandler
  	AddHintProvider(HintProvider)
-	AddPod(pod *v1.Pod, containerID string) error 
- 	RemovePod(containerID string) error 
+	AddContainer(pod *v1.Pod, containerID string) error 
+ 	RemoveContainer(containerID string) error 
  	Store
  }
 
@@ -124,16 +124,16 @@ func (m *manager) AddHintProvider(h HintProvider) {
  	m.hintProviders = append(m.hintProviders, h)
 }
 
-func (m *manager) AddPod(pod *v1.Pod, containerID string) error {
+func (m *manager) AddContainer(pod *v1.Pod, containerID string) error {
 	m.podMap[containerID] = string(pod.UID)
 	return nil
 }
 
-func (m *manager) RemovePod (containerID string) error {
+func (m *manager) RemoveContainer (containerID string) error {
  	podUIDString := m.podMap[containerID]
 	delete(m.podTopologyHints, podUIDString)
 	delete(m.podMap, containerID)
-	klog.Infof("[topologymanager] RemovePod - Container ID: %v podTopologyHints: %v", containerID, m.podTopologyHints)
+	klog.Infof("[topologymanager] RemoveContainer - Container ID: %v podTopologyHints: %v", containerID, m.podTopologyHints)
 	return nil 
 }
 

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -90,10 +90,10 @@ func (m *manager) GetAffinity(podUID string, containerName string) TopologyHint 
 func (m *manager) calculateTopologyAffinity(pod v1.Pod, container v1.Container) (TopologyHint, bool) {
 	socketMask := socketmask.NewSocketMask(nil)
 	var maskHolder []string
-	var socketMaskInt64 [][]int64
 	count := 0 
 	admitPod := true
         for _, hp := range m.hintProviders {
+		var socketMaskInt64 [][]int64
 		topologyHints, admit := hp.GetTopologyHints(pod, container)
 		for r := range topologyHints {
                 	socketMaskVals := []int64(topologyHints[r].SocketMask)

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -46,11 +46,11 @@ type HintProvider interface {
 }
  
 type Store interface {
-	GetAffinity(podUID string, containerName string) []TopologyHint 
+	GetAffinity(podUID string, containerName string) TopologyHint 
 }
 
  
-type containers map[string][]TopologyHint
+type containers map[string]TopologyHint
 var _ Manager = &manager{}
 type policyName string
 func NewManager(topologyPolicyName string) Manager {
@@ -83,11 +83,11 @@ func NewManager(topologyPolicyName string) Manager {
 	return manager
 }
 
-func (m *manager) GetAffinity(podUID string, containerName string) []TopologyHint {
+func (m *manager) GetAffinity(podUID string, containerName string) TopologyHint {
  	return m.podTopologyHints[podUID][containerName]
 }
 
-func (m *manager) calculateTopologyAffinity(pod v1.Pod, container v1.Container) ([]TopologyHint, bool) {
+func (m *manager) calculateTopologyAffinity(pod v1.Pod, container v1.Container) (TopologyHint, bool) {
 	socketMask := socketmask.NewSocketMask(nil)
 	var maskHolder []string
 	var socketMaskInt64 [][]int64
@@ -114,12 +114,10 @@ func (m *manager) calculateTopologyAffinity(pod v1.Pod, container v1.Container) 
 		}
 		
 	}
-	var topologyHints []TopologyHint
 	var topologyHint TopologyHint
 	topologyHint.SocketMask = socketMask 
-	topologyHints = append(topologyHints, topologyHint) 	  
 
-	return topologyHints, admitPod
+	return topologyHint, admitPod
 }
 
 func (m *manager) AddHintProvider(h HintProvider) {

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -1,0 +1,320 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologymanager
+
+import (
+	"reflect"
+	"testing"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/socketmask"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+)
+
+func TestNewManager(t *testing.T) {
+	tcases := []struct {
+		name       string
+		policyType string
+	}{
+		{
+			name:       "Policy is set preferred",
+			policyType: "preferred",
+		},
+		{
+			name:       "Policy is set to strict",
+			policyType: "strict",
+		},
+		{
+			name:       "Policy is set to unknown",
+			policyType: "unknown",
+		},
+	}
+
+	for _, tc := range tcases {
+		mngr := NewManager(tc.policyType)
+
+		if _, ok := mngr.(Manager); !ok {
+			t.Errorf("result is not Manager type")
+		}
+	}
+}
+
+type mockHintProvider struct {
+	th	[]TopologyHint
+	admit	bool
+}
+
+func (m *mockHintProvider) GetTopologyHints(pod v1.Pod, container v1.Container) ([]TopologyHint, bool) {
+	return m.th, m.admit
+}
+
+func TestGetAffinity(t *testing.T) {
+	tcases := []struct {
+		name          string
+		containerName string
+		podUID        string
+		expected      TopologyHint
+	}{
+		{
+			name:          "case1",
+			containerName: "nginx",
+			podUID:        "0aafa4c4-38e8-11e9-bcb1-a4bf01040474",
+			expected: 	TopologyHint{},
+		},
+	}
+	for _, tc := range tcases {
+		mngr := manager{}
+		actual := mngr.GetAffinity(tc.podUID, tc.containerName)
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("Expected Affinity in result to be %v, got %v", tc.expected, actual)
+		}
+	}
+}
+
+func TestCalculateTopologyAffinity(t *testing.T) {
+	tcases := []struct {
+		name     	string
+		hp       	[]HintProvider
+		expectedHint 	TopologyHint
+		expectedAdmit	bool
+	}{
+		{
+			name: 		"TopologyHint not set",
+			hp:   		[]HintProvider{},
+			expectedHint: 	TopologyHint{
+					SocketMask:	nil,
+			},
+			expectedAdmit: 	true,
+		},
+		{
+			name: "TopologyHint set with SocketMask as nil. Admit set as false",
+			hp: []HintProvider{
+				&mockHintProvider{
+					th: 	[]TopologyHint{
+							TopologyHint{
+                                                        	SocketMask: nil,
+                                                        },	
+						},
+					admit:	false,
+				},
+			},
+			expectedHint:	TopologyHint{
+				SocketMask: 	nil,
+			},
+			expectedAdmit:	false,
+		},
+		{
+			name: "TopologyHint set with SocketMask as not nil. Admit set as false",
+			hp: []HintProvider{
+				&mockHintProvider{
+					th:	[]TopologyHint{ 
+							TopologyHint{
+								SocketMask: socketmask.SocketMask{1, 0},
+							},
+							TopologyHint{
+                                                                SocketMask: socketmask.SocketMask{0, 1},
+                                                        }, 
+							TopologyHint{
+                                                                SocketMask: socketmask.SocketMask{1, 1},
+                                                        }, 	
+						},
+					admit:	false,
+				},
+			},
+			expectedHint: TopologyHint{
+				SocketMask: socketmask.SocketMask{1, 0},
+			},
+			expectedAdmit:	false,
+		},
+		{
+			name: "TopologyHint with SocketMask as not nil. Admit set as true",
+			hp: []HintProvider{
+				&mockHintProvider{
+					th: 	[]TopologyHint{
+							TopologyHint{
+								SocketMask: socketmask.SocketMask{1, 0},
+							},
+							TopologyHint{
+                                                                SocketMask: socketmask.SocketMask{0, 1},
+                                                        },
+							TopologyHint{
+                                                                SocketMask: socketmask.SocketMask{1, 1},
+                                                        },
+
+						},
+					admit: true,
+				},
+			},
+			expectedHint:	TopologyHint{
+				SocketMask: socketmask.SocketMask{1, 0},
+			},
+			expectedAdmit:	true,
+		},
+	}
+
+	for _, tc := range tcases {
+		mngr := manager{}
+		mngr.hintProviders = tc.hp
+		_, admit := mngr.calculateTopologyAffinity(v1.Pod{}, v1.Container{})
+		if !reflect.DeepEqual(admit, tc.expectedAdmit) {
+			t.Errorf("Expected Affinity in result to be %v, got %v", tc.expectedAdmit, admit)
+		}
+	}
+}
+
+func TestAddContainer(t *testing.T) {
+	testCases := []struct {
+		name        string
+		containerID string
+		podUID      types.UID
+	}{
+		{
+			name:        "Case1",
+			containerID: "nginx",
+			podUID:      "0aafa4c4-38e8-11e9-bcb1-a4bf01040474",
+		},
+		{
+			name:        "Case2",
+			containerID: "Busy_Box",
+			podUID:      "b3ee37fc-39a5-11e9-bcb1-a4bf01040474",
+		},
+	}
+	mngr := manager{}
+	mngr.podMap = make(map[string]string)
+	for _, tc := range testCases {
+		pod := v1.Pod{}
+		pod.UID = tc.podUID
+		err := mngr.AddContainer(&pod, tc.containerID)
+		if err != nil {
+			t.Errorf("Expected error to be nil but got: %v", err)
+		}
+		if val, ok := mngr.podMap[tc.containerID]; ok {
+			if reflect.DeepEqual(val, pod.UID) {
+				t.Errorf("Error occurred")
+			}
+		} else {
+			t.Errorf("Error occurred, Pod not added to podMap")
+		}
+	}
+}
+
+func TestRemoveContainer(t *testing.T) {
+	testCases := []struct {
+		name        string
+		containerID string
+		podUID      types.UID
+	}{
+		{
+			name:        "Case1",
+			containerID: "nginx",
+			podUID:      "0aafa4c4-38e8-11e9-bcb1-a4bf01040474",
+		},
+		{
+			name:        "Case2",
+			containerID: "Busy_Box",
+			podUID:      "b3ee37fc-39a5-11e9-bcb1-a4bf01040474",
+		},
+	}
+	var len1, len2 int
+	mngr := manager{}
+	mngr.podMap = make(map[string]string)
+	for _, tc := range testCases {
+		mngr.podMap[tc.containerID] = string(tc.podUID)
+		len1 = len(mngr.podMap)
+		err := mngr.RemoveContainer(tc.containerID)
+		len2 = len(mngr.podMap)
+		if err != nil {
+			t.Errorf("Expected error to be nil but got: %v", err)
+		}
+		if len1-len2 != 1 {
+			t.Errorf("Remove Pod resulted in error")
+		}
+	}
+
+}
+func TestAddHintProvider(t *testing.T) {
+	var len1 int
+	tcases := []struct {
+		name string
+		hp   []HintProvider
+	}{
+		{
+			name: "Add HintProvider",
+			hp: []HintProvider{
+				&mockHintProvider{
+					th:	[]TopologyHint{
+							TopologyHint{
+								SocketMask: nil,
+							},
+						},
+					admit:	true,
+				},
+			},
+		},
+	}
+	mngr := manager{}
+	for _, tc := range tcases {
+		mngr.hintProviders = []HintProvider{}
+		len1 = len(mngr.hintProviders)
+		mngr.AddHintProvider(tc.hp[0])
+	}
+	len2 := len(mngr.hintProviders)
+	if len2-len1 != 1 {
+		t.Errorf("error")
+	}
+}
+
+func TestAdmit(t *testing.T) {
+	tcases := []struct {
+		name     string
+		result   lifecycle.PodAdmitResult
+		qosClass v1.PodQOSClass
+		expected bool
+	}{
+		{
+			name:     "QOSClass set as Gauranteed",
+			result:   lifecycle.PodAdmitResult{},
+			qosClass: "Guaranteed",
+			expected: true,
+		},
+		{
+			name:     "QOSClass set as Burstable",
+			result:   lifecycle.PodAdmitResult{},
+			qosClass: "Burstable",
+			expected: true,
+		},
+		{
+			name:     "QOSClass set as BestEffort",
+			result:   lifecycle.PodAdmitResult{},
+			qosClass: "BestEffort",
+			expected: true,
+		},
+	}
+	for _, tc := range tcases {
+		man := manager{}
+		man.podTopologyHints = make(map[string]containers)
+		podAttr := lifecycle.PodAdmitAttributes{}
+		pod := v1.Pod{}
+		pod.Status.QOSClass = tc.qosClass
+		podAttr.Pod = &pod
+		//c := make(containers)
+		actual := man.Admit(&podAttr)
+		if reflect.DeepEqual(actual, tc.result) {
+			t.Errorf("Error occured, expected Admit in result to be %v got %v", tc.result, actual.Admit)
+		}
+	}
+}


### PR DESCRIPTION
TopologyHints -> TopologyHint
SocketAffinity -> SocketMask
Affinity -> admit
TopologyHint contains SocketMask only
GetTopologyHints returns ([]TopologyHint, admit bool)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
 /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
-->

**Which issue(s) this PR fixes**:
Unintuitive TopologyHints semantics
https://docs.google.com/document/d/1UbD1igeBA1sRuqwkQgJ5sJ9sf1rao_LLORWLhwSdGUo/edit#

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
