### PR TITLE
Ensure preferred hints are always chosen over non-preferred hints

### DIFF
--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -205,15 +205,28 @@ func (m *manager) calculateAffinity(pod v1.Pod, container v1.Container) Topology
 			return
 		}
 
-		// Only consider mergedHints that have a narrower SocketAffinity than
-		// the SocketAffinityi in the current bestHint as a replacement for the
-		// current bestHint.
+		// If the current bestHint is non-preferred and the new mergedHint is
+		// preferred, always choose the preferred hint over the non-preferred one.
+		if mergedHint.Preferred && !bestHint.Preferred {
+			bestHint = mergedHint
+			return
+		}
+
+		// If the current bestHint is preferred and the new mergedHint is
+		// non-preferred, never update bestHint, regardless of mergedHint's
+		// narowness.
+		if !mergedHint.Preferred && bestHint.Preferred {
+			return
+		}
+
+		// If mergedHint and bestHint has the same preference, only consider
+		// mergedHints that have a narrower SocketAffinity than the
+		// SocketAffinity in the current bestHint.
 		if !mergedHint.SocketAffinity.IsNarrowerThan(bestHint.SocketAffinity) {
 			return
 		}
 
-		// If we made it past all the checks above, set the new bestHint as the
-		// current mergedHint.
+		// In all other cases, update bestHint to the current mergedHint
 		bestHint = mergedHint
 	})
 

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -107,7 +107,7 @@ func TestCalculateAffinity(t *testing.T) {
 			hp:   []HintProvider{},
 			expected: TopologyHint{
 				SocketAffinity: NewTestSocketMaskFull(),
-				Preferred:      false,
+				Preferred:      true,
 			},
 		},
 		{
@@ -124,7 +124,7 @@ func TestCalculateAffinity(t *testing.T) {
 			},
 			expected: TopologyHint{
 				SocketAffinity: NewTestSocketMaskFull(),
-				Preferred:      false,
+				Preferred:      true,
 			},
 		},
 		{
@@ -141,7 +141,7 @@ func TestCalculateAffinity(t *testing.T) {
 			},
 			expected: TopologyHint{
 				SocketAffinity: NewTestSocketMaskFull(),
-				Preferred:      false,
+				Preferred:      true,
 			},
 		},
 		{
@@ -472,6 +472,43 @@ func TestCalculateAffinity(t *testing.T) {
 			},
 			expected: TopologyHint{
 				SocketAffinity: NewTestSocketMask(0),
+				Preferred:      true,
+			},
+		},
+		{
+			name: "Ensure less narrow preferred hints are chosen over narrower non-preferred hints",
+			hp: []HintProvider{
+				&mockHintProvider{
+					[]TopologyHint{
+						{
+							SocketAffinity: NewTestSocketMask(1),
+							Preferred:      true,
+						},
+						{
+							SocketAffinity: NewTestSocketMask(0, 1),
+							Preferred:      false,
+						},
+					},
+				},
+				&mockHintProvider{
+					[]TopologyHint{
+						{
+							SocketAffinity: NewTestSocketMask(0),
+							Preferred:      true,
+						},
+						{
+							SocketAffinity: NewTestSocketMask(1),
+							Preferred:      true,
+						},
+						{
+							SocketAffinity: NewTestSocketMask(0, 1),
+							Preferred:      false,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				SocketAffinity: NewTestSocketMask(1),
 				Preferred:      true,
 			},
 		},


### PR DESCRIPTION
Previously, only the "narrowness" of a merged TopologyHint was being
considered when deciding if one hint was better than another. Now we
make sure to never choose a non-preferred hint over a preferred one if a
preferred one is available.