### PR TITLE
Edits based on comments + none policy implementation

### DIFF
--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -77,6 +77,9 @@ func NewManager(topologyPolicyName string) Manager {
 
 	switch topologyPolicyName {
 
+	case PolicyNone:
+		policy = NewNonePolicy()
+
 	case PolicyPreferred:
 		policy = NewPreferredPolicy()
 
@@ -84,8 +87,8 @@ func NewManager(topologyPolicyName string) Manager {
 		policy = NewStrictPolicy()
 
 	default:
-		klog.Errorf("[topologymanager] Unknown policy %s, using default policy %s", topologyPolicyName, PolicyPreferred)
-		policy = NewPreferredPolicy()
+		klog.Errorf("[topologymanager] Unknown policy %s, using default policy %s", topologyPolicyName, PolicyNone)
+		policy = NewNonePolicy()
 	}
 
 	var hp []HintProvider
@@ -161,7 +164,7 @@ func (m *manager) calculateAffinity(pod v1.Pod, container v1.Container) Topology
 		hints := provider.GetTopologyHints(pod, container)
 
 		// If hints is nil, overwrite 'hints' with a preferred any-socket affinity.
-		if hints == nil {
+		if hints == nil || len(hints) == 0 {
 			klog.Infof("[topologymanager] Hint Provider has no preference for socket affinity")
 			affinity, _ := socketmask.NewSocketMask()
 			affinity.Fill()
@@ -257,6 +260,12 @@ func (m *manager) RemoveContainer(containerID string) error {
 
 func (m *manager) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
 	klog.Infof("[topologymanager] Topology Admit Handler")
+	if m.policy.Name() == "none" {
+		klog.Infof("[topologymanager] Skipping calculate topology affinity as policy: none")
+		return lifecycle.PodAdmitResult{
+			Admit: true,
+		}
+	}
 	pod := attrs.Pod
 	c := make(map[string]TopologyHint)
 	klog.Infof("[topologymanager] Pod QoS Level: %v", pod.Status.QOSClass)


### PR DESCRIPTION
Additional test cases
Enable none policy by default

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Updates from feedback including unit test cases + none policy by default
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Closing #38 and combining updates with this PR, will need rebase after #79343 is merged
**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
